### PR TITLE
Add incremental deployment feature flags

### DIFF
--- a/charts/root-app/templates/argo-cd.yaml
+++ b/charts/root-app/templates/argo-cd.yaml
@@ -1,3 +1,4 @@
+{{- if (index .Values.apps "argo-cd").enabled }}
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
@@ -16,3 +17,4 @@ spec:
   syncPolicy:
     automated:
       selfHeal: true
+{{- end }}

--- a/charts/root-app/templates/docker-registry.yaml
+++ b/charts/root-app/templates/docker-registry.yaml
@@ -1,3 +1,4 @@
+{{- if (index .Values.apps "docker-registry").enabled }}
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
@@ -16,3 +17,4 @@ spec:
   syncPolicy:
     automated:
       selfHeal: true
+{{- end }}

--- a/charts/root-app/templates/finance-app-database-service.yaml
+++ b/charts/root-app/templates/finance-app-database-service.yaml
@@ -1,3 +1,4 @@
+{{- if (index .Values.apps "finance-app-database-service").enabled }}
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
@@ -16,3 +17,4 @@ spec:
   syncPolicy:
     automated:
       selfHeal: true
+{{- end }}

--- a/charts/root-app/templates/grafana.yaml
+++ b/charts/root-app/templates/grafana.yaml
@@ -1,3 +1,4 @@
+{{- if (index .Values.apps "grafana").enabled }}
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
@@ -16,3 +17,4 @@ spec:
   syncPolicy:
     automated:
       selfHeal: true
+{{- end }}

--- a/charts/root-app/templates/openfaas.yaml
+++ b/charts/root-app/templates/openfaas.yaml
@@ -1,3 +1,4 @@
+{{- if (index .Values.apps "openfaas").enabled }}
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
@@ -16,3 +17,4 @@ spec:
   syncPolicy:
     automated:
       selfHeal: true
+{{- end }}

--- a/charts/root-app/templates/postgresql.yaml
+++ b/charts/root-app/templates/postgresql.yaml
@@ -1,3 +1,4 @@
+{{- if (index .Values.apps "postgresql").enabled }}
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
@@ -16,3 +17,4 @@ spec:
   syncPolicy:
     automated:
       selfHeal: true
+{{- end }}

--- a/charts/root-app/templates/prometheus.yaml
+++ b/charts/root-app/templates/prometheus.yaml
@@ -1,3 +1,4 @@
+{{- if (index .Values.apps "prometheus").enabled }}
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
@@ -16,3 +17,4 @@ spec:
   syncPolicy:
     automated:
       selfHeal: true
+{{- end }}

--- a/charts/root-app/templates/scraper-manager.yaml
+++ b/charts/root-app/templates/scraper-manager.yaml
@@ -1,3 +1,4 @@
+{{- if (index .Values.apps "scraper-manager").enabled }}
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
@@ -16,3 +17,4 @@ spec:
   syncPolicy:
     automated:
       selfHeal: false
+{{- end }}

--- a/charts/root-app/templates/tekton-dashboard.yaml
+++ b/charts/root-app/templates/tekton-dashboard.yaml
@@ -1,3 +1,4 @@
+{{- if (index .Values.apps "tekton-dashboard").enabled }}
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
@@ -16,3 +17,4 @@ spec:
   syncPolicy:
     automated:
       selfHeal: true
+{{- end }}

--- a/charts/root-app/templates/tekton-pipeline-hello-world.yaml
+++ b/charts/root-app/templates/tekton-pipeline-hello-world.yaml
@@ -1,3 +1,4 @@
+{{- if (index .Values.apps "tekton-pipeline-hello-world").enabled }}
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
@@ -16,3 +17,4 @@ spec:
   syncPolicy:
     automated:
       selfHeal: true
+{{- end }}

--- a/charts/root-app/templates/tekton-pipeline.yaml
+++ b/charts/root-app/templates/tekton-pipeline.yaml
@@ -1,3 +1,4 @@
+{{- if (index .Values.apps "tekton-pipeline").enabled }}
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
@@ -16,3 +17,4 @@ spec:
   syncPolicy:
     automated:
       selfHeal: true
+{{- end }}

--- a/charts/root-app/templates/tekton-triggers.yaml
+++ b/charts/root-app/templates/tekton-triggers.yaml
@@ -1,3 +1,4 @@
+{{- if (index .Values.apps "tekton-triggers").enabled }}
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
@@ -16,3 +17,4 @@ spec:
   syncPolicy:
     automated:
       selfHeal: true
+{{- end }}

--- a/charts/root-app/templates/uptime-kuma.yaml
+++ b/charts/root-app/templates/uptime-kuma.yaml
@@ -1,3 +1,4 @@
+{{- if (index .Values.apps "uptime-kuma").enabled }}
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
@@ -16,3 +17,4 @@ spec:
   syncPolicy:
     automated:
       selfHeal: true
+{{- end }}

--- a/charts/root-app/templates/yfinance-wrapper.yaml
+++ b/charts/root-app/templates/yfinance-wrapper.yaml
@@ -1,3 +1,4 @@
+{{- if (index .Values.apps "yfinance-wrapper").enabled }}
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
@@ -16,3 +17,4 @@ spec:
   syncPolicy:
     automated:
       selfHeal: true
+{{- end }}

--- a/charts/root-app/values.yaml
+++ b/charts/root-app/values.yaml
@@ -1,0 +1,29 @@
+apps:
+  argo-cd:
+    enabled: true
+  docker-registry:
+    enabled: false
+  finance-app-database-service:
+    enabled: false
+  grafana:
+    enabled: false
+  openfaas:
+    enabled: false
+  postgresql:
+    enabled: false
+  prometheus:
+    enabled: false
+  scraper-manager:
+    enabled: false
+  tekton-dashboard:
+    enabled: false
+  tekton-pipeline:
+    enabled: false
+  tekton-pipeline-hello-world:
+    enabled: false
+  tekton-triggers:
+    enabled: false
+  uptime-kuma:
+    enabled: false
+  yfinance-wrapper:
+    enabled: false


### PR DESCRIPTION
Wrap all ArgoCD Application templates with conditional Helm guards based on per-app enabled flags in values.yaml. All apps default to disabled except ArgoCD itself, enabling operators to selectively enable applications for staged rollouts.

This implements the incremental deployment pattern, allowing fine-grained control over which applications are deployed to the cluster.