### PR TITLE
Fix ArgoCD app-of-apps namespace and disable self-management

### DIFF
--- a/charts/root-app/templates/argo-cd.yaml
+++ b/charts/root-app/templates/argo-cd.yaml
@@ -1,3 +1,4 @@
+{{- if (index .Values.apps "argo-cd").enabled }}
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
@@ -16,3 +17,4 @@ spec:
   syncPolicy:
     automated:
       selfHeal: true
+{{- end }}

--- a/charts/root-app/templates/argo-cd.yaml
+++ b/charts/root-app/templates/argo-cd.yaml
@@ -3,6 +3,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: argo-cd
+  namespace: argocd
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:
@@ -13,7 +14,7 @@ spec:
     targetRevision: HEAD
   destination:
     server: https://kubernetes.default.svc
-    namespace: default
+    namespace: argocd
   syncPolicy:
     automated:
       selfHeal: true

--- a/charts/root-app/templates/docker-registry.yaml
+++ b/charts/root-app/templates/docker-registry.yaml
@@ -3,6 +3,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: docker-registry
+  namespace: argocd
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:

--- a/charts/root-app/templates/docker-registry.yaml
+++ b/charts/root-app/templates/docker-registry.yaml
@@ -1,3 +1,4 @@
+{{- if (index .Values.apps "docker-registry").enabled }}
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
@@ -16,3 +17,4 @@ spec:
   syncPolicy:
     automated:
       selfHeal: true
+{{- end }}

--- a/charts/root-app/templates/finance-app-database-service.yaml
+++ b/charts/root-app/templates/finance-app-database-service.yaml
@@ -3,6 +3,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: finance-app-database-service
+  namespace: argocd
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:

--- a/charts/root-app/templates/finance-app-database-service.yaml
+++ b/charts/root-app/templates/finance-app-database-service.yaml
@@ -1,3 +1,4 @@
+{{- if (index .Values.apps "finance-app-database-service").enabled }}
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
@@ -16,3 +17,4 @@ spec:
   syncPolicy:
     automated:
       selfHeal: true
+{{- end }}

--- a/charts/root-app/templates/grafana.yaml
+++ b/charts/root-app/templates/grafana.yaml
@@ -1,3 +1,4 @@
+{{- if (index .Values.apps "grafana").enabled }}
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
@@ -16,3 +17,4 @@ spec:
   syncPolicy:
     automated:
       selfHeal: true
+{{- end }}

--- a/charts/root-app/templates/grafana.yaml
+++ b/charts/root-app/templates/grafana.yaml
@@ -3,6 +3,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: grafana
+  namespace: argocd
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:

--- a/charts/root-app/templates/openfaas.yaml
+++ b/charts/root-app/templates/openfaas.yaml
@@ -3,6 +3,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: openfaas
+  namespace: argocd
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:

--- a/charts/root-app/templates/openfaas.yaml
+++ b/charts/root-app/templates/openfaas.yaml
@@ -1,3 +1,4 @@
+{{- if (index .Values.apps "openfaas").enabled }}
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
@@ -16,3 +17,4 @@ spec:
   syncPolicy:
     automated:
       selfHeal: true
+{{- end }}

--- a/charts/root-app/templates/postgresql.yaml
+++ b/charts/root-app/templates/postgresql.yaml
@@ -1,3 +1,4 @@
+{{- if (index .Values.apps "postgresql").enabled }}
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
@@ -16,3 +17,4 @@ spec:
   syncPolicy:
     automated:
       selfHeal: true
+{{- end }}

--- a/charts/root-app/templates/postgresql.yaml
+++ b/charts/root-app/templates/postgresql.yaml
@@ -3,6 +3,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: postgresql
+  namespace: argocd
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:

--- a/charts/root-app/templates/prometheus.yaml
+++ b/charts/root-app/templates/prometheus.yaml
@@ -1,3 +1,4 @@
+{{- if (index .Values.apps "prometheus").enabled }}
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
@@ -16,3 +17,4 @@ spec:
   syncPolicy:
     automated:
       selfHeal: true
+{{- end }}

--- a/charts/root-app/templates/prometheus.yaml
+++ b/charts/root-app/templates/prometheus.yaml
@@ -3,6 +3,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: prometheus
+  namespace: argocd
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:

--- a/charts/root-app/templates/root-app.yaml
+++ b/charts/root-app/templates/root-app.yaml
@@ -2,6 +2,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: root-app
+  namespace: argocd
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:
@@ -12,7 +13,7 @@ spec:
     targetRevision: HEAD
   destination:
     server: https://kubernetes.default.svc
-    namespace: default
+    namespace: argocd
   syncPolicy:
     automated:
       selfHeal: true

--- a/charts/root-app/templates/scraper-manager.yaml
+++ b/charts/root-app/templates/scraper-manager.yaml
@@ -3,6 +3,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: scraper-manager
+  namespace: argocd
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:

--- a/charts/root-app/templates/scraper-manager.yaml
+++ b/charts/root-app/templates/scraper-manager.yaml
@@ -1,3 +1,4 @@
+{{- if (index .Values.apps "scraper-manager").enabled }}
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
@@ -16,3 +17,4 @@ spec:
   syncPolicy:
     automated:
       selfHeal: false
+{{- end }}

--- a/charts/root-app/templates/tekton-dashboard.yaml
+++ b/charts/root-app/templates/tekton-dashboard.yaml
@@ -1,3 +1,4 @@
+{{- if (index .Values.apps "tekton-dashboard").enabled }}
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
@@ -16,3 +17,4 @@ spec:
   syncPolicy:
     automated:
       selfHeal: true
+{{- end }}

--- a/charts/root-app/templates/tekton-dashboard.yaml
+++ b/charts/root-app/templates/tekton-dashboard.yaml
@@ -3,6 +3,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: tekton-dashboard
+  namespace: argocd
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:

--- a/charts/root-app/templates/tekton-pipeline-hello-world.yaml
+++ b/charts/root-app/templates/tekton-pipeline-hello-world.yaml
@@ -1,3 +1,4 @@
+{{- if (index .Values.apps "tekton-pipeline-hello-world").enabled }}
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
@@ -16,3 +17,4 @@ spec:
   syncPolicy:
     automated:
       selfHeal: true
+{{- end }}

--- a/charts/root-app/templates/tekton-pipeline-hello-world.yaml
+++ b/charts/root-app/templates/tekton-pipeline-hello-world.yaml
@@ -3,6 +3,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: tekton-pipeline-hello-world
+  namespace: argocd
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:

--- a/charts/root-app/templates/tekton-pipeline.yaml
+++ b/charts/root-app/templates/tekton-pipeline.yaml
@@ -1,3 +1,4 @@
+{{- if (index .Values.apps "tekton-pipeline").enabled }}
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
@@ -16,3 +17,4 @@ spec:
   syncPolicy:
     automated:
       selfHeal: true
+{{- end }}

--- a/charts/root-app/templates/tekton-pipeline.yaml
+++ b/charts/root-app/templates/tekton-pipeline.yaml
@@ -3,6 +3,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: tekton-pipeline
+  namespace: argocd
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:

--- a/charts/root-app/templates/tekton-triggers.yaml
+++ b/charts/root-app/templates/tekton-triggers.yaml
@@ -3,6 +3,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: tekton-triggers
+  namespace: argocd
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:

--- a/charts/root-app/templates/tekton-triggers.yaml
+++ b/charts/root-app/templates/tekton-triggers.yaml
@@ -1,3 +1,4 @@
+{{- if (index .Values.apps "tekton-triggers").enabled }}
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
@@ -16,3 +17,4 @@ spec:
   syncPolicy:
     automated:
       selfHeal: true
+{{- end }}

--- a/charts/root-app/templates/uptime-kuma.yaml
+++ b/charts/root-app/templates/uptime-kuma.yaml
@@ -3,6 +3,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: uptime-kuma
+  namespace: argocd
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:

--- a/charts/root-app/templates/uptime-kuma.yaml
+++ b/charts/root-app/templates/uptime-kuma.yaml
@@ -1,3 +1,4 @@
+{{- if (index .Values.apps "uptime-kuma").enabled }}
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
@@ -16,3 +17,4 @@ spec:
   syncPolicy:
     automated:
       selfHeal: true
+{{- end }}

--- a/charts/root-app/templates/yfinance-wrapper.yaml
+++ b/charts/root-app/templates/yfinance-wrapper.yaml
@@ -3,6 +3,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: yfinance-wrapper
+  namespace: argocd
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:

--- a/charts/root-app/templates/yfinance-wrapper.yaml
+++ b/charts/root-app/templates/yfinance-wrapper.yaml
@@ -1,3 +1,4 @@
+{{- if (index .Values.apps "yfinance-wrapper").enabled }}
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
@@ -16,3 +17,4 @@ spec:
   syncPolicy:
     automated:
       selfHeal: true
+{{- end }}

--- a/charts/root-app/values.yaml
+++ b/charts/root-app/values.yaml
@@ -1,6 +1,6 @@
 apps:
   argo-cd:
-    enabled: true
+    enabled: false
   docker-registry:
     enabled: false
   finance-app-database-service:

--- a/charts/root-app/values.yaml
+++ b/charts/root-app/values.yaml
@@ -1,0 +1,29 @@
+apps:
+  argo-cd:
+    enabled: true
+  docker-registry:
+    enabled: false
+  finance-app-database-service:
+    enabled: false
+  grafana:
+    enabled: false
+  openfaas:
+    enabled: false
+  postgresql:
+    enabled: false
+  prometheus:
+    enabled: false
+  scraper-manager:
+    enabled: false
+  tekton-dashboard:
+    enabled: false
+  tekton-pipeline:
+    enabled: false
+  tekton-pipeline-hello-world:
+    enabled: false
+  tekton-triggers:
+    enabled: false
+  uptime-kuma:
+    enabled: false
+  yfinance-wrapper:
+    enabled: false


### PR DESCRIPTION
## Summary
- Add `namespace: argocd` to all Application template metadata so child apps are created in the correct namespace
- Change root-app destination from `default` to `argocd`
- Disable `argo-cd` child app to avoid conflicts with the existing Helm-managed ArgoCD installation

## Context
ArgoCD was showing OutOfSync because Application resources were being created in the `default` namespace instead of `argocd`. Additionally, the argo-cd child app was trying to manage ArgoCD with an old chart version (5.2.1) conflicting with the live install (9.4.4).