### PR TITLE
fix: add missing closing template tag in docker-registry

### DIFF
--- a/charts/root-app/templates/docker-registry.yaml
+++ b/charts/root-app/templates/docker-registry.yaml
@@ -21,3 +21,4 @@ spec:
       selfHeal: true
     syncOptions:
     - CreateNamespace=true
+{{- end }}


### PR DESCRIPTION
## Summary
Added missing closing `{{- end }}` tag in the docker-registry helm template, which was causing ArgoCD to fail with "unexpected EOF" during helm template generation.

## Test plan
- Verified helm template renders without errors
- Confirmed all other root-app templates are properly closed

🤖 Generated with [Claude Code](https://claude.com/claude-code)