### PR TITLE
feat: add NGINX Ingress and Caddy TLS gateway

### DIFF
--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -1,0 +1,13 @@
+{
+	local_certs
+}
+
+*.lucas.engineering {
+	tls internal
+	reverse_proxy 192.168.20.192:30080 {
+		header_up Host {host}
+		header_up X-Real-IP {remote_host}
+		header_up X-Forwarded-For {remote_host}
+		header_up X-Forwarded-Proto {scheme}
+	}
+}

--- a/charts/argo-cd/Chart.lock
+++ b/charts/argo-cd/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: argo-cd
   repository: https://argoproj.github.io/argo-helm
-  version: 5.2.1
-digest: sha256:e149dd3aa06b821671b528d43c2dfb5ef8f04962ca177fa6ad37dacf1cb778f5
-generated: "2023-11-09T09:10:52.831639-05:00"
+  version: 7.8.13
+digest: sha256:b4427ab92e9b3bccd25042de62c29f0c52174a4d0a6c74d935a6f8edc6ab6f20
+generated: "2026-02-25T09:58:10.457797-05:00"

--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,5 +3,5 @@ name: argo-cd
 version: 1.0.0
 dependencies:
   - name: argo-cd
-    version: 5.2.1
+    version: 7.8.13
     repository: https://argoproj.github.io/argo-helm

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -1,4 +1,6 @@
 argo-cd:
+  global:
+    domain: argocd.lucas.engineering
   dex:
     enabled: false
   notifications:
@@ -9,6 +11,7 @@ argo-cd:
     extraArgs:
       - --insecure
     service:
-      type: LoadBalancer
-      servicePortHttp: 8081
-      servicePortHttps: 8443
+      type: ClusterIP
+    ingress:
+      enabled: true
+      ingressClassName: nginx

--- a/charts/docker-registry/values.yaml
+++ b/charts/docker-registry/values.yaml
@@ -1,6 +1,13 @@
 docker-registry:
   service:
-    type: LoadBalancer
+    type: ClusterIP
+  ingress:
+    enabled: true
+    className: nginx
+    hosts:
+      - registry.lucas.engineering
+    annotations:
+      nginx.ingress.kubernetes.io/proxy-body-size: "0"
   persistence:
     enabled: true
     size: 10Gi

--- a/charts/finance-app-database-service/deployment.yaml
+++ b/charts/finance-app-database-service/deployment.yaml
@@ -9,7 +9,7 @@ spec:
   - protocol: "TCP"
     port: 8091
     targetPort: 8000
-  type: LoadBalancer
+  type: ClusterIP
 
 ---
 
@@ -37,3 +37,23 @@ spec:
           value: "Value of the test variable"
         ports:
         - containerPort: 8000
+
+---
+
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: finance-app-database-service
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: finance-db.lucas.engineering
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: finance-app-database-service
+            port:
+              number: 8091

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -1,9 +1,13 @@
 grafana:
-  service: 
-    type: LoadBalancer
-    port: 8083
+  service:
+    type: ClusterIP
   persistence:
     enabled: true
+  ingress:
+    enabled: true
+    ingressClassName: nginx
+    hosts:
+      - grafana.lucas.engineering
   spec:
     containers:
       resources:

--- a/charts/ingress-nginx/Chart.lock
+++ b/charts/ingress-nginx/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: ingress-nginx
+  repository: https://kubernetes.github.io/ingress-nginx
+  version: 4.11.3
+digest: sha256:0963a4470e5fe0ce97023b16cfc9c3cde18b74707c6379947542e09afa6d5346
+generated: "2026-02-25T09:56:05.643462-05:00"

--- a/charts/ingress-nginx/Chart.yaml
+++ b/charts/ingress-nginx/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v2
+name: ingress-nginx
+version: 1.0.0
+dependencies:
+  - name: ingress-nginx
+    version: 4.11.3
+    repository: https://kubernetes.github.io/ingress-nginx

--- a/charts/ingress-nginx/values.yaml
+++ b/charts/ingress-nginx/values.yaml
@@ -1,0 +1,14 @@
+ingress-nginx:
+  controller:
+    ingressClassResource:
+      name: nginx
+      default: true
+    service:
+      type: NodePort
+      nodePorts:
+        http: 30080
+        https: 30443
+    config:
+      use-forwarded-headers: "true"
+      compute-real-ip: "true"
+      proxy-real-ip-cidr: "192.168.20.0/24"

--- a/charts/openfaas/values.yaml
+++ b/charts/openfaas/values.yaml
@@ -1,2 +1,16 @@
 openfaas:
-  serviceType: LoadBalancer
+  serviceType: ClusterIP
+  ingress:
+    enabled: true
+    ingressClassName: nginx
+    hosts:
+    - host: openfaas.lucas.engineering
+      http:
+        paths:
+        - path: /
+          pathType: Prefix
+          backend:
+            service:
+              name: gateway
+              port:
+                number: 8080

--- a/charts/postgresql/values.yaml
+++ b/charts/postgresql/values.yaml
@@ -4,4 +4,4 @@ postgresql:
     database: "testdb"
   primary:
     service:
-      type: LoadBalancer
+      type: ClusterIP

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -1,5 +1,9 @@
 prometheus:
   server:
-    service: 
-      servicePort: 8082
-      type: LoadBalancer
+    service:
+      type: ClusterIP
+    ingress:
+      enabled: true
+      ingressClassName: nginx
+      hosts:
+        - prometheus.lucas.engineering

--- a/charts/root-app/templates/ingress-nginx.yaml
+++ b/charts/root-app/templates/ingress-nginx.yaml
@@ -1,8 +1,8 @@
-{{- if (index .Values.apps "argo-cd").enabled }}
+{{- if (index .Values.apps "ingress-nginx").enabled }}
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: argo-cd
+  name: ingress-nginx
   namespace: argocd
   finalizers:
   - resources-finalizer.argocd.argoproj.io
@@ -10,11 +10,11 @@ spec:
   project: default
   source:
     repoURL: https://github.com/lward27/lucas_engineering.git
-    path: charts/argo-cd
+    path: charts/ingress-nginx
     targetRevision: HEAD
   destination:
     server: https://kubernetes.default.svc
-    namespace: argocd
+    namespace: ingress-nginx
   syncPolicy:
     automated:
       prune: true

--- a/charts/root-app/values.yaml
+++ b/charts/root-app/values.yaml
@@ -7,6 +7,8 @@ apps:
     enabled: false
   grafana:
     enabled: false
+  ingress-nginx:
+    enabled: false
   openfaas:
     enabled: false
   postgresql:

--- a/charts/uptime-kuma/values.yaml
+++ b/charts/uptime-kuma/values.yaml
@@ -1,4 +1,11 @@
 uptime-kuma:
   service:
-    type: LoadBalancer
-    
+    type: ClusterIP
+  ingress:
+    enabled: true
+    className: nginx
+    hosts:
+      - host: uptime.lucas.engineering
+        paths:
+          - path: /
+            pathType: ImplementationSpecific

--- a/charts/yfinance-wrapper/deployment.yaml
+++ b/charts/yfinance-wrapper/deployment.yaml
@@ -11,7 +11,7 @@ spec:
   - protocol: "TCP"
     port: 8090
     targetPort: 8000
-  type: LoadBalancer
+  type: ClusterIP
 
 ---
 
@@ -39,3 +39,23 @@ spec:
           value: "Value of the test variable"
         ports:
         - containerPort: 8000
+
+---
+
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: yfinance-wrapper
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: yfinance.lucas.engineering
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: yfinance-wrapper
+            port:
+              number: 8090


### PR DESCRIPTION
## Summary
Migrate all services from LoadBalancer to subdomain-based routing via Caddy TLS termination and NGINX Ingress Controller. Each service is now accessible at its own subdomain (argocd.lucas.engineering, grafana.lucas.engineering, etc.) under the wildcard *.lucas.engineering DNS record.

**Key changes:**
- Created ingress-nginx Helm chart (deployed as NodePort on 30080/30443)
- Upgraded ArgoCD from chart v5.2.1 to v7.8.13 and brought it under app-of-apps management
- All platform services now use ClusterIP with ingress resources configured
- Added Caddyfile for reverse proxy with local_certs TLS termination
- Updated raw manifest services (yfinance-wrapper, finance-app-database-service) with Ingress resources

All apps remain disabled in root-app/values.yaml pending deployment decision.

## Deployment sequence
1. Enable `ingress-nginx` in root-app/values.yaml
2. Enable `argo-cd` to redeploy with ClusterIP + ingress
3. Deploy Caddyfile to VM and reload Caddy
4. Test argocd.lucas.engineering, then enable additional services

🤖 Generated with [Claude Code](https://claude.com/claude-code)