### PR TITLE
chore: update all Helm charts to latest versions

### DIFF
--- a/charts/argo-cd/Chart.lock
+++ b/charts/argo-cd/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: argo-cd
   repository: https://argoproj.github.io/argo-helm
-  version: 7.8.13
-digest: sha256:b4427ab92e9b3bccd25042de62c29f0c52174a4d0a6c74d935a6f8edc6ab6f20
-generated: "2026-02-25T09:58:10.457797-05:00"
+  version: 9.4.4
+digest: sha256:59ffd6c161b43fcdda59ae94ad343c17a5e5e3b4bae93acca84a34ff31d29b9c
+generated: "2026-02-25T10:53:42.2165-05:00"

--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,5 +3,5 @@ name: argo-cd
 version: 1.0.0
 dependencies:
   - name: argo-cd
-    version: 7.8.13
+    version: 9.4.4
     repository: https://argoproj.github.io/argo-helm

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -1,6 +1,9 @@
 argo-cd:
   global:
     domain: argocd.lucas.engineering
+  configs:
+    params:
+      server.insecure: "true"
   dex:
     enabled: false
   notifications:
@@ -8,8 +11,6 @@ argo-cd:
   applicationSet:
     enabled: false
   server:
-    extraArgs:
-      - --insecure
     service:
       type: ClusterIP
     ingress:

--- a/charts/docker-registry/Chart.lock
+++ b/charts/docker-registry/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: docker-registry
+  repository: https://twuni.github.io/docker-registry.helm
+  version: 3.0.0
+digest: sha256:427b6a2ec73d739e6b6a71fd2f184924a7df8d3d3d9ca63a337d8f01d2f59d36
+generated: "2026-02-25T10:55:34.179386-05:00"

--- a/charts/docker-registry/Chart.yaml
+++ b/charts/docker-registry/Chart.yaml
@@ -3,5 +3,5 @@ name: docker-registry
 version: 1.0.0
 dependencies:
   - name: docker-registry
-    version: 2.2.2
+    version: 3.0.0
     repository: https://twuni.github.io/docker-registry.helm

--- a/charts/docker-registry/values.yaml
+++ b/charts/docker-registry/values.yaml
@@ -1,4 +1,5 @@
 docker-registry:
+  configPath: /etc/distribution
   service:
     type: ClusterIP
   ingress:

--- a/charts/grafana/Chart.lock
+++ b/charts/grafana/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: grafana
+  repository: https://grafana.github.io/helm-charts
+  version: 10.5.15
+digest: sha256:3fd0080197abb0a1968d174ead7180f962c939cab8037f1b8ead6dd3adfa7490
+generated: "2026-02-25T10:54:49.587778-05:00"

--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -3,5 +3,5 @@ name: grafana
 version: 1.0.0
 dependencies:
   - name: grafana
-    version: 7.0.3
+    version: 10.5.15
     repository: https://grafana.github.io/helm-charts

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -8,12 +8,10 @@ grafana:
     ingressClassName: nginx
     hosts:
       - grafana.lucas.engineering
-  spec:
-    containers:
-      resources:
-        limits:
-          cpu: 1000m
-          memory: 2048Mi
-        requests:
-          cpu: 500m
-          memory: 1024Mi
+  resources:
+    limits:
+      cpu: 1000m
+      memory: 2048Mi
+    requests:
+      cpu: 500m
+      memory: 1024Mi

--- a/charts/ingress-nginx/Chart.lock
+++ b/charts/ingress-nginx/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: ingress-nginx
   repository: https://kubernetes.github.io/ingress-nginx
-  version: 4.11.3
-digest: sha256:0963a4470e5fe0ce97023b16cfc9c3cde18b74707c6379947542e09afa6d5346
-generated: "2026-02-25T09:56:05.643462-05:00"
+  version: 4.14.3
+digest: sha256:1244dafdb3897abc361ad238afa9b52c9b16046eb23a93e5420693bebe7feea9
+generated: "2026-02-25T10:54:05.056783-05:00"

--- a/charts/ingress-nginx/Chart.yaml
+++ b/charts/ingress-nginx/Chart.yaml
@@ -3,5 +3,5 @@ name: ingress-nginx
 version: 1.0.0
 dependencies:
   - name: ingress-nginx
-    version: 4.11.3
+    version: 4.14.3
     repository: https://kubernetes.github.io/ingress-nginx

--- a/charts/openfaas/Chart.lock
+++ b/charts/openfaas/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: openfaas
+  repository: https://openfaas.github.io/faas-netes/
+  version: 14.2.135
+digest: sha256:638094e00ade1357cd97f679ff560d771f37f3c159fdc41d29cbe80a541eb9c3
+generated: "2026-02-25T10:56:19.324226-05:00"

--- a/charts/openfaas/Chart.yaml
+++ b/charts/openfaas/Chart.yaml
@@ -3,5 +3,5 @@ name: openfaas
 version: 1.0.0
 dependencies:
   - name: openfaas
-    version: 14.1.19
+    version: 14.2.135
     repository: https://openfaas.github.io/faas-netes/

--- a/charts/postgresql/Chart.lock
+++ b/charts/postgresql/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: postgresql
+  repository: oci://registry-1.docker.io/bitnamicharts
+  version: 18.4.1
+digest: sha256:2d7c3bd5a0184f020110a31804602a3d1f78f18f1ece024783517f24c16f3490
+generated: "2026-02-25T10:54:27.848466-05:00"

--- a/charts/postgresql/Chart.yaml
+++ b/charts/postgresql/Chart.yaml
@@ -3,5 +3,5 @@ name: postgresql
 version: 1.0.0
 dependencies:
   - name: postgresql
-    version: 18.4.0
+    version: 18.4.1
     repository: oci://registry-1.docker.io/bitnamicharts

--- a/charts/prometheus/Chart.lock
+++ b/charts/prometheus/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: prometheus
+  repository: https://prometheus-community.github.io/helm-charts
+  version: 28.9.1
+digest: sha256:1fca72ba4c4b4f53a47dacf4a6f05362d9dd05ed7617d9a0fd6f8a2bafa813af
+generated: "2026-02-25T10:55:12.917169-05:00"

--- a/charts/prometheus/Chart.yaml
+++ b/charts/prometheus/Chart.yaml
@@ -3,5 +3,5 @@ name: prometheus
 version: 1.0.0
 dependencies:
   - name: prometheus
-    version: 25.3.1
+    version: 28.9.1
     repository: https://prometheus-community.github.io/helm-charts

--- a/charts/uptime-kuma/Chart.lock
+++ b/charts/uptime-kuma/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: uptime-kuma
+  repository: https://helm.irsigler.cloud/
+  version: 4.0.0
+digest: sha256:4f069ce790c7fbaeab1675b2d5a183a05881f457e7c5b19b0051a5abe832f632
+generated: "2026-02-25T10:55:56.951592-05:00"

--- a/charts/uptime-kuma/Chart.yaml
+++ b/charts/uptime-kuma/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
-name: postgresql
+name: uptime-kuma
 version: 1.0.0
 dependencies:
   - name: uptime-kuma
-    version: 2.15.0
+    version: 4.0.0
     repository: https://helm.irsigler.cloud/


### PR DESCRIPTION
## Summary

Updated 8 Helm charts to their latest stable versions with necessary configuration fixes for breaking changes discovered during upgrade research.

**Version updates:**
- argo-cd 7.8.13 → 9.4.4 (ArgoCD v3.3.2)
- ingress-nginx 4.11.3 → 4.14.3
- postgresql 18.4.0 → 18.4.1
- grafana 7.0.3 → 10.5.15 (Grafana 12.3.1)
- prometheus 25.3.1 → 28.9.1
- docker-registry 2.2.2 → 3.0.0 (Distribution v3)
- uptime-kuma 2.15.0 → 4.0.0
- openfaas 14.1.19 → 14.2.135

**Breaking changes addressed:**
- argo-cd: Replaced `server.extraArgs: [--insecure]` with `configs.params.server.insecure: "true"`
- grafana: Fixed `spec.containers.resources` to top-level `resources` (was never working)
- docker-registry: Added `configPath: /etc/distribution` for Distribution v3 compatibility
- uptime-kuma: Fixed Chart.yaml name from `postgresql` to `uptime-kuma` (copy-paste error)