### PR TITLE
Add LGTM stack components to ArgoCD

### DIFF
--- a/charts/loki/Chart.yaml
+++ b/charts/loki/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v2
+name: loki
+version: 1.0.0
+dependencies:
+  - name: loki
+    version: 6.53.0
+    repository: https://grafana.github.io/helm-charts

--- a/charts/loki/values.yaml
+++ b/charts/loki/values.yaml
@@ -1,0 +1,25 @@
+loki:
+  deploymentMode: SingleBinary
+  loki:
+    auth_enabled: false
+    commonConfig:
+      replication_factor: 1
+    storage:
+      type: filesystem
+    schemaConfig:
+      configs:
+        - from: "2024-01-01"
+          store: tsdb
+          object_store: filesystem
+          schema: v13
+          index:
+            prefix: loki_index_
+            period: 24h
+  singleBinary:
+    replicas: 1
+  read:
+    replicas: 0
+  write:
+    replicas: 0
+  backend:
+    replicas: 0

--- a/charts/mimir/Chart.yaml
+++ b/charts/mimir/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v2
+name: mimir
+version: 1.0.0
+dependencies:
+  - name: mimir-distributed
+    version: 6.0.0
+    repository: https://grafana.github.io/helm-charts

--- a/charts/mimir/values.yaml
+++ b/charts/mimir/values.yaml
@@ -1,0 +1,8 @@
+mimir-distributed:
+  mimir:
+    structuredConfig:
+      common:
+        storage:
+          backend: filesystem
+  minio:
+    enabled: false

--- a/charts/opentelemetry-collector/Chart.yaml
+++ b/charts/opentelemetry-collector/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v2
+name: opentelemetry-collector
+version: 1.0.0
+dependencies:
+  - name: opentelemetry-collector
+    version: 0.146.0
+    repository: https://open-telemetry.github.io/opentelemetry-helm-charts

--- a/charts/opentelemetry-collector/values.yaml
+++ b/charts/opentelemetry-collector/values.yaml
@@ -1,0 +1,30 @@
+opentelemetry-collector:
+  mode: deployment
+  config:
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+            endpoint: "0.0.0.0:4317"
+          http:
+            endpoint: "0.0.0.0:4318"
+    exporters:
+      otlphttp/loki:
+        endpoint: http://loki.monitoring.svc.cluster.local:3100/otlp
+      otlp/tempo:
+        endpoint: http://tempo.monitoring.svc.cluster.local:4317
+        tls:
+          insecure: true
+      otlphttp/mimir:
+        endpoint: http://mimir-mimir-distributed-gateway.monitoring.svc.cluster.local:80/otlp
+    service:
+      pipelines:
+        traces:
+          receivers: [otlp]
+          exporters: [otlp/tempo]
+        logs:
+          receivers: [otlp]
+          exporters: [otlphttp/loki]
+        metrics:
+          receivers: [otlp]
+          exporters: [otlphttp/mimir]

--- a/charts/root-app/templates/loki.yaml
+++ b/charts/root-app/templates/loki.yaml
@@ -1,0 +1,22 @@
+{{- if (index .Values.apps "loki").enabled }}
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: loki
+  namespace: argocd
+  finalizers:
+  - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/lward27/lucas_engineering.git
+    path: charts/loki
+    targetRevision: HEAD
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: monitoring
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+{{- end }}

--- a/charts/root-app/templates/mimir.yaml
+++ b/charts/root-app/templates/mimir.yaml
@@ -1,0 +1,22 @@
+{{- if (index .Values.apps "mimir").enabled }}
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: mimir
+  namespace: argocd
+  finalizers:
+  - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/lward27/lucas_engineering.git
+    path: charts/mimir
+    targetRevision: HEAD
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: monitoring
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+{{- end }}

--- a/charts/root-app/templates/opentelemetry-collector.yaml
+++ b/charts/root-app/templates/opentelemetry-collector.yaml
@@ -1,0 +1,22 @@
+{{- if (index .Values.apps "opentelemetry-collector").enabled }}
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: opentelemetry-collector
+  namespace: argocd
+  finalizers:
+  - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/lward27/lucas_engineering.git
+    path: charts/opentelemetry-collector
+    targetRevision: HEAD
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: monitoring
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+{{- end }}

--- a/charts/root-app/templates/tempo.yaml
+++ b/charts/root-app/templates/tempo.yaml
@@ -1,0 +1,22 @@
+{{- if (index .Values.apps "tempo").enabled }}
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: tempo
+  namespace: argocd
+  finalizers:
+  - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/lward27/lucas_engineering.git
+    path: charts/tempo
+    targetRevision: HEAD
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: monitoring
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+{{- end }}

--- a/charts/root-app/values.yaml
+++ b/charts/root-app/values.yaml
@@ -9,7 +9,13 @@ apps:
     enabled: true
   ingress-nginx:
     enabled: true
+  loki:
+    enabled: false
+  mimir:
+    enabled: false
   openfaas:
+    enabled: false
+  opentelemetry-collector:
     enabled: false
   postgresql:
     enabled: true
@@ -24,6 +30,8 @@ apps:
   tekton-pipeline-hello-world:
     enabled: false
   tekton-triggers:
+    enabled: false
+  tempo:
     enabled: false
   uptime-kuma:
     enabled: true

--- a/charts/tempo/Chart.yaml
+++ b/charts/tempo/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v2
+name: tempo
+version: 1.0.0
+dependencies:
+  - name: tempo
+    version: 1.24.4
+    repository: https://grafana.github.io/helm-charts

--- a/charts/tempo/values.yaml
+++ b/charts/tempo/values.yaml
@@ -1,0 +1,9 @@
+tempo:
+  tempo:
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+            endpoint: "0.0.0.0:4317"
+          http:
+            endpoint: "0.0.0.0:4318"


### PR DESCRIPTION
## Summary
Added complete LGTM observability stack to ArgoCD app-of-apps pattern. Includes four new Helm wrapper charts and ArgoCD Application manifests for Loki (logs), Tempo (traces), Mimir (long-term metrics), and OpenTelemetry Collector (telemetry ingestion). All components are deployed to the monitoring namespace with automated sync policies enabled.

## Components Added
- **Loki** (v6.53.0): SingleBinary log aggregation with filesystem storage
- **Tempo** (v1.24.4): Distributed tracing with OTLP receivers
- **Mimir** (v6.0.0): Long-term metrics storage with filesystem backend
- **OpenTelemetry Collector** (v0.146.0): Configured to route traces→Tempo, logs→Loki, metrics→Mimir

All services are disabled by default (enabled: false) and ready to deploy when needed.

🤖 Generated with Claude Code