### PR TITLE
Fix K8s pod scheduling: reduce memory requests for 16GB node

### DIFF
--- a/charts/docker-registry/values.yaml
+++ b/charts/docker-registry/values.yaml
@@ -14,8 +14,8 @@ docker-registry:
     size: 10Gi
   resources:
     limits:
-      cpu: 1000m
-      memory: 2048Mi
+      cpu: 200m
+      memory: 256Mi
     requests:
-      cpu: 500m
-      memory: 1024Mi
+      cpu: 50m
+      memory: 128Mi

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -10,8 +10,8 @@ grafana:
       - grafana.lucas.engineering
   resources:
     limits:
-      cpu: 1000m
-      memory: 2048Mi
-    requests:
       cpu: 500m
-      memory: 1024Mi
+      memory: 512Mi
+    requests:
+      cpu: 100m
+      memory: 256Mi

--- a/charts/loki/values.yaml
+++ b/charts/loki/values.yaml
@@ -17,9 +17,20 @@ loki:
             period: 24h
   singleBinary:
     replicas: 1
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        memory: 512Mi
   read:
     replicas: 0
   write:
     replicas: 0
   backend:
     replicas: 0
+  # Disable memcached caches - not needed for single-binary mode on a small node
+  chunksCache:
+    enabled: false
+  resultsCache:
+    enabled: false

--- a/charts/mimir/values.yaml
+++ b/charts/mimir/values.yaml
@@ -6,3 +6,108 @@ mimir-distributed:
           backend: filesystem
   minio:
     enabled: false
+
+  # Disable Kafka - not needed for a single-node deployment
+  kafka:
+    enabled: false
+
+  # Disable zone-aware replication and use minimal replicas
+  ingester:
+    zoneAwareReplication:
+      enabled: false
+    replicas: 1
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+      limits:
+        memory: 512Mi
+
+  store_gateway:
+    zoneAwareReplication:
+      enabled: false
+    replicas: 1
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+      limits:
+        memory: 256Mi
+
+  compactor:
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+      limits:
+        memory: 256Mi
+
+  distributor:
+    replicas: 1
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+      limits:
+        memory: 256Mi
+
+  querier:
+    replicas: 1
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+      limits:
+        memory: 256Mi
+
+  query_frontend:
+    replicas: 1
+    resources:
+      requests:
+        cpu: 100m
+        memory: 64Mi
+      limits:
+        memory: 128Mi
+
+  query_scheduler:
+    replicas: 1
+    resources:
+      requests:
+        cpu: 100m
+        memory: 64Mi
+      limits:
+        memory: 128Mi
+
+  ruler:
+    replicas: 1
+    resources:
+      requests:
+        cpu: 100m
+        memory: 64Mi
+      limits:
+        memory: 128Mi
+
+  alertmanager:
+    resources:
+      requests:
+        cpu: 50m
+        memory: 32Mi
+      limits:
+        memory: 64Mi
+
+  overrides_exporter:
+    replicas: 1
+    resources:
+      requests:
+        cpu: 50m
+        memory: 32Mi
+      limits:
+        memory: 64Mi
+
+  rollout_operator:
+    resources:
+      requests:
+        cpu: 50m
+        memory: 32Mi
+      limits:
+        memory: 64Mi


### PR DESCRIPTION
## Summary

- **Loki**: Disabled memcached chunks-cache (9.8Gi request!) and results-cache (1.2Gi) — these are unnecessary in single-binary mode and were the #1 cause of the scheduling failures
- **Mimir**: Disabled zone-aware replication (was deploying 3x ingester zones + 3x store-gateway zones) and Kafka; reduced all component replicas to 1 with right-sized requests for a homelab
- **Grafana**: Reduced memory request from 1Gi → 256Mi, limit from 2Gi → 512Mi
- **Docker Registry**: Reduced memory request from 1Gi → 128Mi, limit from 2Gi → 256Mi

Total memory requests reduced from ~18Gi to ~1.8Gi on a 16Gi node.

## Root cause

Kubernetes schedules pods based on resource *requests*, not actual usage. The Helm chart defaults for Loki (memcached caches) and Mimir (multi-zone distributed mode) are designed for large production clusters, not a single-node homelab. The combined requests exceeded the node's 16Gi allocatable memory, causing `Insufficient memory` scheduling errors even though actual RAM usage was only 3.6Gi.

## Test plan
- [ ] Verify ArgoCD syncs all four changed apps successfully
- [ ] Confirm all previously-Pending pods are now Running
- [ ] Check `kubectl describe node` shows reasonable memory allocation percentage
- [ ] Verify Grafana, Loki, Mimir, and Docker Registry are functional

🤖 Generated with [Claude Code](https://claude.com/claude-code)