### PR TITLE
Fix Mimir ingest storage and Grafana init container

### DIFF
--- a/charts/docker-registry/values.yaml
+++ b/charts/docker-registry/values.yaml
@@ -14,8 +14,8 @@ docker-registry:
     size: 10Gi
   resources:
     limits:
-      cpu: 1000m
-      memory: 2048Mi
+      cpu: 200m
+      memory: 256Mi
     requests:
-      cpu: 500m
-      memory: 1024Mi
+      cpu: 50m
+      memory: 128Mi

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -3,6 +3,8 @@ grafana:
     type: ClusterIP
   persistence:
     enabled: true
+  initChownData:
+    enabled: false
   ingress:
     enabled: true
     ingressClassName: nginx

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -10,8 +10,8 @@ grafana:
       - grafana.lucas.engineering
   resources:
     limits:
-      cpu: 1000m
-      memory: 2048Mi
-    requests:
       cpu: 500m
-      memory: 1024Mi
+      memory: 512Mi
+    requests:
+      cpu: 100m
+      memory: 256Mi

--- a/charts/loki/values.yaml
+++ b/charts/loki/values.yaml
@@ -17,9 +17,20 @@ loki:
             period: 24h
   singleBinary:
     replicas: 1
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        memory: 512Mi
   read:
     replicas: 0
   write:
     replicas: 0
   backend:
     replicas: 0
+  # Disable memcached caches - not needed for single-binary mode on a small node
+  chunksCache:
+    enabled: false
+  resultsCache:
+    enabled: false

--- a/charts/mimir/values.yaml
+++ b/charts/mimir/values.yaml
@@ -6,3 +6,108 @@ mimir-distributed:
           backend: filesystem
   minio:
     enabled: false
+
+  # Disable Kafka - not needed for a single-node deployment
+  kafka:
+    enabled: false
+
+  # Disable zone-aware replication and use minimal replicas
+  ingester:
+    zoneAwareReplication:
+      enabled: false
+    replicas: 1
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+      limits:
+        memory: 512Mi
+
+  store_gateway:
+    zoneAwareReplication:
+      enabled: false
+    replicas: 1
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+      limits:
+        memory: 256Mi
+
+  compactor:
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+      limits:
+        memory: 256Mi
+
+  distributor:
+    replicas: 1
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+      limits:
+        memory: 256Mi
+
+  querier:
+    replicas: 1
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+      limits:
+        memory: 256Mi
+
+  query_frontend:
+    replicas: 1
+    resources:
+      requests:
+        cpu: 100m
+        memory: 64Mi
+      limits:
+        memory: 128Mi
+
+  query_scheduler:
+    replicas: 1
+    resources:
+      requests:
+        cpu: 100m
+        memory: 64Mi
+      limits:
+        memory: 128Mi
+
+  ruler:
+    replicas: 1
+    resources:
+      requests:
+        cpu: 100m
+        memory: 64Mi
+      limits:
+        memory: 128Mi
+
+  alertmanager:
+    resources:
+      requests:
+        cpu: 50m
+        memory: 32Mi
+      limits:
+        memory: 64Mi
+
+  overrides_exporter:
+    replicas: 1
+    resources:
+      requests:
+        cpu: 50m
+        memory: 32Mi
+      limits:
+        memory: 64Mi
+
+  rollout_operator:
+    resources:
+      requests:
+        cpu: 50m
+        memory: 32Mi
+      limits:
+        memory: 64Mi

--- a/charts/mimir/values.yaml
+++ b/charts/mimir/values.yaml
@@ -4,6 +4,11 @@ mimir-distributed:
       common:
         storage:
           backend: filesystem
+      # Disable Kafka-based ingest storage — use classic push path instead
+      ingest_storage:
+        enabled: false
+      ingester:
+        push_grpc_method_enabled: true
   minio:
     enabled: false
 


### PR DESCRIPTION
## Summary

- **Mimir**: Disable Kafka-based ingest storage in `structuredConfig` and re-enable classic gRPC push path. Setting `kafka.enabled: false` only skips deploying the Kafka StatefulSet but doesn't disable the ingest storage feature in Mimir's config, causing all components to crash with `invalid ingest storage config: the Kafka address has not been configured`
- **Grafana**: Disable `initChownData` init container that fails with `Permission denied` when trying to chown the existing PVC

## Test plan
- [ ] All Mimir pods reach Running state (compactor, distributor, ingester, querier, ruler, store-gateway)
- [ ] Grafana new pod starts without init container failure
- [ ] Loki cache DNS errors stop appearing in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)