### PR TITLE
Fix Mimir blocks_storage backend to filesystem

### DIFF
--- a/charts/mimir/values.yaml
+++ b/charts/mimir/values.yaml
@@ -4,6 +4,13 @@ mimir-distributed:
       common:
         storage:
           backend: filesystem
+      # Override chart default of s3 to use local filesystem
+      blocks_storage:
+        backend: filesystem
+        filesystem:
+          dir: /data/tsdb
+        bucket_store:
+          sync_dir: /data/tsdb-sync
       # Disable Kafka-based ingest storage — use classic push path instead
       ingest_storage:
         enabled: false


### PR DESCRIPTION
## Summary

- Set `blocks_storage.backend: filesystem` explicitly in Mimir's structuredConfig to override the chart default of `s3`
- Components (ruler, querier, store-gateway, compactor) were crashing with `no s3 endpoint in config file`

🤖 Generated with [Claude Code](https://claude.com/claude-code)