### PR TITLE
Fix Mimir blocks_storage filesystem dir overlap

### DIFF
--- a/charts/mimir/values.yaml
+++ b/charts/mimir/values.yaml
@@ -8,7 +8,7 @@ mimir-distributed:
       blocks_storage:
         backend: filesystem
         filesystem:
-          dir: /data/tsdb
+          dir: /data/blocks
         bucket_store:
           sync_dir: /data/tsdb-sync
       # Disable Kafka-based ingest storage — use classic push path instead


### PR DESCRIPTION
## Summary

- Fix path overlap between `blocks_storage.filesystem.dir` and `blocks_storage.tsdb.dir` (both were `/data/tsdb`)
- Changed filesystem dir to `/data/blocks` to resolve Mimir startup validation error

🤖 Generated with [Claude Code](https://claude.com/claude-code)