### PR TITLE
Fix Mimir data dir overlaps for filesystem storage

### DIFF
--- a/charts/mimir/values.yaml
+++ b/charts/mimir/values.yaml
@@ -11,6 +11,13 @@ mimir-distributed:
           dir: /data/blocks
         bucket_store:
           sync_dir: /data/tsdb-sync
+      # Separate data dirs so none overlap with blocks_storage.filesystem.dir
+      compactor:
+        data_dir: /data/compactor
+      ruler:
+        rule_path: /data/ruler
+      alertmanager:
+        data_dir: /data/alertmanager
       # Disable Kafka-based ingest storage — use classic push path instead
       ingest_storage:
         enabled: false


### PR DESCRIPTION
## Summary

- Separate compactor, ruler, and alertmanager data dirs into subdirectories (`/data/compactor`, `/data/ruler`, `/data/alertmanager`) so they don't overlap with `blocks_storage.filesystem.dir=/data/blocks`
- Mimir validates that no data directories overlap with the blocks storage filesystem directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)