### PR TITLE
Fix Mimir: data dir overlaps and disable rollout-operator

### DIFF
--- a/charts/mimir/values.yaml
+++ b/charts/mimir/values.yaml
@@ -124,9 +124,4 @@ mimir-distributed:
         memory: 64Mi
 
   rollout_operator:
-    resources:
-      requests:
-        cpu: 50m
-        memory: 32Mi
-      limits:
-        memory: 64Mi
+    enabled: false


### PR DESCRIPTION
## Summary

- Separate compactor, ruler, alertmanager data dirs into subdirectories to prevent overlap with blocks_storage filesystem dir
- Disable rollout-operator which creates webhooks with wrong TLS cert SAN, blocking ArgoCD from syncing StatefulSet updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)