### PR TITLE
Connect Prometheus remote_write to Mimir and provision Grafana datasources

### DIFF
--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -17,3 +17,22 @@ grafana:
     requests:
       cpu: 100m
       memory: 256Mi
+  datasources:
+    datasources.yaml:
+      apiVersion: 1
+      datasources:
+        - name: Prometheus
+          type: prometheus
+          url: http://prometheus-server.monitoring.svc
+          access: proxy
+          isDefault: true
+        - name: Mimir
+          type: prometheus
+          url: http://mimir-gateway.monitoring.svc/prometheus
+          access: proxy
+          isDefault: false
+        - name: Loki
+          type: loki
+          url: http://loki-gateway.monitoring.svc
+          access: proxy
+          isDefault: false

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -7,3 +7,44 @@ prometheus:
       ingressClassName: nginx
       hosts:
         - prometheus.lucas.engineering
+    remoteWrite:
+      - url: http://mimir-gateway.monitoring.svc/api/v1/push
+  extraScrapeConfigs: |
+    - job_name: mimir
+      kubernetes_sd_configs:
+        - role: pod
+          namespaces:
+            names:
+              - monitoring
+      relabel_configs:
+        - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_name]
+          regex: mimir
+          action: keep
+        - source_labels: [__meta_kubernetes_pod_container_port_name]
+          regex: http-metrics
+          action: keep
+        - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_component]
+          target_label: component
+        - source_labels: [__meta_kubernetes_namespace]
+          target_label: namespace
+        - source_labels: [__meta_kubernetes_pod_name]
+          target_label: pod
+    - job_name: loki
+      kubernetes_sd_configs:
+        - role: pod
+          namespaces:
+            names:
+              - monitoring
+      relabel_configs:
+        - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_name]
+          regex: loki
+          action: keep
+        - source_labels: [__meta_kubernetes_pod_container_port_name]
+          regex: http-metrics
+          action: keep
+        - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_component]
+          target_label: component
+        - source_labels: [__meta_kubernetes_namespace]
+          target_label: namespace
+        - source_labels: [__meta_kubernetes_pod_name]
+          target_label: pod


### PR DESCRIPTION
## Summary

- **Prometheus**: Configure `remote_write` to Mimir gateway (`/api/v1/push`) so all collected metrics are stored in Mimir
- **Prometheus**: Add dedicated scrape configs for Mimir and Loki pod metrics (port 8080 http-metrics) so their operational dashboards work
- **Grafana**: Provision three datasources via Helm: Prometheus (default), Mimir, and Loki

## Test plan
- [ ] Verify Prometheus remote_write is active (check Prometheus UI status page)
- [ ] Query Mimir via Grafana — `up` metric should return results
- [ ] Mimir dashboards (Writes, Rollout, etc.) should show data after a few minutes of scraping
- [ ] Loki datasource should be queryable in Grafana Explore

🤖 Generated with [Claude Code](https://claude.com/claude-code)