### PR TITLE
Enable finance-app-database-service with Prometheus monitoring

### DIFF
--- a/charts/finance-app-database-service/deployment.yaml
+++ b/charts/finance-app-database-service/deployment.yaml
@@ -2,6 +2,10 @@ apiVersion: v1
 kind: Service
 metadata:
   name: finance-app-database-service
+  annotations:
+    prometheus.io/scrape: 'true'
+    prometheus.io/port: '8091'
+    prometheus.io/path: '/metrics'
 spec:
   selector:
     app: finance-app-database-service
@@ -26,7 +30,10 @@ spec:
     metadata:
       labels:
         app: finance-app-database-service
-
+      annotations:
+        prometheus.io/scrape: 'true'
+        prometheus.io/port: '8000'
+        prometheus.io/path: '/metrics'
     spec:
       containers:
       - name: finance-app-database-service

--- a/charts/root-app/values.yaml
+++ b/charts/root-app/values.yaml
@@ -4,7 +4,7 @@ apps:
   docker-registry:
     enabled: true
   finance-app-database-service:
-    enabled: false
+    enabled: true
   grafana:
     enabled: true
   ingress-nginx:


### PR DESCRIPTION
## Summary
- Enable the finance-app-database-service in the ArgoCD app-of-apps pattern
- Add Prometheus scrape annotations to expose metrics at port 8000 on `/metrics` endpoint
- Service will now send metrics to Prometheus, which automatically ships them to Mimir via remote write
- Grafana already has Prometheus and Mimir configured as datasources

## Deployment
Service deploys to `apps-prod` namespace and is accessible at `finance-db.lucas.engineering`.

## Testing
Verify in Prometheus that the service is being scraped and metrics are visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)