### PR TITLE
fix: use registry.lucas.engineering for image refs

### DIFF
--- a/charts/finance-app-database-service/deployment.yaml
+++ b/charts/finance-app-database-service/deployment.yaml
@@ -37,7 +37,7 @@ spec:
     spec:
       containers:
       - name: finance-app-database-service
-        image: docker.lucas.engineering/finance_app_database_service:0.4
+        image: registry.lucas.engineering/finance_app_database_service:0.4
         imagePullPolicy: IfNotPresent
         env:
         - name: TEST_VARIABLE

--- a/charts/scraper-manager/deployment.yaml
+++ b/charts/scraper-manager/deployment.yaml
@@ -7,6 +7,6 @@ spec:
     spec:
       containers:
       - name: scraper-manager
-        image: docker.lucas.engineering/scraper_manager:0.7
+        image: registry.lucas.engineering/scraper_manager:0.7
       restartPolicy: Never
   backoffLimit: 1

--- a/charts/tekton-pipeline-financeapp/pipelinerun-yfinance_wrapper.yaml
+++ b/charts/tekton-pipeline-financeapp/pipelinerun-yfinance_wrapper.yaml
@@ -21,4 +21,4 @@ spec:
   - name: repo-url
     value: https://github.com/lward27/yfinance_wrapper.git
   - name: image-reference
-    value: docker.lucas.engineering/yfinance_wrapper:0.5
+    value: registry.lucas.engineering/yfinance_wrapper:0.5


### PR DESCRIPTION
## Summary
- Replaced `docker.lucas.engineering` with `registry.lucas.engineering` in all image references
- `docker.lucas.engineering` is not configured in k3s `registries.yaml`, causing TLS verification failures (Caddy uses self-signed internal certs)
- `registry.lucas.engineering` is already configured with `insecure_skip_verify: true` and has a matching ingress rule

## Changed files
- `charts/finance-app-database-service/deployment.yaml` — fixes the failing deployment
- `charts/scraper-manager/deployment.yaml` — proactive fix for same issue
- `charts/tekton-pipeline-financeapp/pipelinerun-yfinance_wrapper.yaml` — consistency fix

## Test plan
- [ ] Verify ArgoCD syncs the finance-app-database-service deployment
- [ ] Confirm the pod starts successfully and pulls the image
- [ ] Verify the finance-db.lucas.engineering endpoint is reachable

🤖 Generated with [Claude Code](https://claude.com/claude-code)