### PR TITLE
fix: cluster health issues - ghost probe, tekton binding, mimir memory

### DIFF
--- a/charts/ghost/ghost-deployment.yaml
+++ b/charts/ghost/ghost-deployment.yaml
@@ -56,9 +56,10 @@ spec:
             failureThreshold: 3
           readinessProbe:
             httpGet:
-              path: /ghost/api/v4/admin/site/
+              path: /
               port: 2368
             periodSeconds: 5
+            failureThreshold: 3
           resources:
             requests:
               memory: "256Mi"

--- a/charts/mimir/values.yaml
+++ b/charts/mimir/values.yaml
@@ -44,10 +44,13 @@ mimir-distributed:
     replicas: 1
     resources:
       requests:
-        cpu: 100m
-        memory: 128Mi
-      limits:
+        cpu: 200m
         memory: 512Mi
+      limits:
+        memory: 1Gi
+    # Use stable release instead of RC
+    image:
+      tag: 3.0.0
 
   store_gateway:
     zoneAwareReplication:

--- a/charts/tekton-ci/templates/triggers/event-listener.yaml
+++ b/charts/tekton-ci/templates/triggers/event-listener.yaml
@@ -33,6 +33,7 @@ spec:
                 body.ref == 'refs/heads/{{ $svc.branch }}'
       bindings:
         - ref: {{ $name }}-binding
+          kind: TriggerBinding
       template:
         ref: {{ $name }}-template
     {{- end }}


### PR DESCRIPTION
Fixes:

- Ghost: Change readiness probe from /ghost/api/v4/admin/site/ to / to avoid HTTPS redirect issues

- Tekton: Add explicit kind: TriggerBinding to EventListener bindings for v0.25+ compatibility

- Mimir: Increase ingester memory limits 512Mi->1Gi and use stable 3.0.0 image instead of 3.0.0-rc.2

Addresses:

- Ghost readiness probe failures due to HTTP->HTTPS redirect

- Tekton EventListener validation webhook errors

- Mimir ingester restart loop (217 restarts) from OOM/memory pressure